### PR TITLE
Add missing QAction include

### DIFF
--- a/src/prefspaneldialog.cpp
+++ b/src/prefspaneldialog.cpp
@@ -15,6 +15,7 @@
 #include "hyphenate/fmhyphenator.h"
 #include "fmpaths.h"
 
+#include <QAction>
 #include <QDebug>
 #include <QToolTip>
 #include <QSettings>


### PR DESCRIPTION
Here's a small fix that was necessary for me to build Fontmatrix with Qt 5.11.3.

Thanks so much for porting this program to Qt 5!